### PR TITLE
Upload file preferences restricted to admins and webmaster

### DIFF
--- a/lib/api/SessionAPI.dart
+++ b/lib/api/SessionAPI.dart
@@ -77,7 +77,7 @@ void saveStatus(Map<String, dynamic> status) async {
   API.prefs.setString("status", status["status"]);
   API.prefs.setString("version", status["version"]);
   API.prefs.setStringList("available_sizes", status["available_sizes"].cast<String>());
-  if(API.prefs.getBool("is_logged") && !API.prefs.getBool("is_guest")) {
+  if(API.prefs.getString("user_status") == "admin" || API.prefs.getString("user_status") == "webmaster") {
     API.prefs.setInt('upload_form_chunk_size', status['upload_form_chunk_size']);
     API.prefs.setString("file_types", status["upload_file_types"]);
   }

--- a/lib/api/SessionAPI.dart
+++ b/lib/api/SessionAPI.dart
@@ -98,6 +98,7 @@ void savePreferences(Map<String, dynamic> status, {
   API.prefs.setString('password', password);
   API.prefs.setBool("is_logged", isLogged);
   API.prefs.setBool("is_guest", isGuest);
+  API.prefs.setString("user_status", status["status"]);
   API.prefs.setString("base_url", url);
 
   API.prefs.setString("default_album", "Root Album");

--- a/lib/views/SettingsPage.dart
+++ b/lib/views/SettingsPage.dart
@@ -127,14 +127,14 @@ class _SettingsPageState extends State<SettingsPage> {
                             child: Text('${API.prefs.getBool('is_guest') ? 'Log in' : 'Log out' }', style: TextStyle(color: Color(0xffff7700), fontSize: 20)),
                           ),
                         ),
-                        API.prefs.getBool('is_guest') ?
-                          Text('') :
+                        API.prefs.getString('user_status') == 'admin' || API.prefs.getString('user_status') == 'webmaster' ?
                           Center(
                             child: Container(
                               padding: EdgeInsets.all(5),
                               child: Text('This server handles these file types: ${API.prefs.getString("file_types").replaceAll(",", ", ")}', textAlign: TextAlign.center, style: TextStyle(color: Colors.black, fontSize: 12)),
                             ),
-                          ),
+                          ) :
+                          Text(''),
                         /*
                         // TODO: Implement albums options
                         SizedBox(height: 20),


### PR DESCRIPTION
Bring in workarounds to #18: add the user's status to the shared preferences, assign and display both **upload_form_chunk_size** and **file_types** prefs only when the logged user is an _admin_ or a _webmaster_ because those variables are [only returned by pwg.session.getStatus then](https://github.com/Piwigo/Piwigo/blob/e3d08b74bf395a3f1ff7aef2ae3a8b0374a64026/include/ws_functions/pwg.php#L400-L413).

While this PR only solves the related issue, the **user_status** pref could replace **is_guest** pref in the long run since it provide the same information: a guest's user status is _guest_.