### PR TITLE
Replace images_picker with image_picker

### DIFF
--- a/lib/services/upload/Uploader.dart
+++ b/lib/services/upload/Uploader.dart
@@ -4,8 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:images_picker/images_picker.dart';
-import 'package:multi_image_picker/multi_image_picker.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:piwigo_ng/api/API.dart';
 import 'package:piwigo_ng/constants/SettingsConstants.dart';
 import 'package:piwigo_ng/views/components/snackbars.dart';
@@ -42,7 +41,7 @@ class Uploader {
     );
   }
 
-  Future<void> uploadPhotos(List<Media> photos, String category, Map<String, dynamic> info) async {
+  Future<void> uploadPhotos(List<XFile> photos, String category, Map<String, dynamic> info) async {
     Map<String, dynamic> result = {
       'isSuccess': true,
       'filePath': null,
@@ -67,13 +66,10 @@ class Uploader {
     await _showUploadNotification(result);
   }
 
-  void upload(Media photo, String category) async {
+  void upload(XFile photo, String category) async {
     Map<String, String> queries = {"format":"json", "method": "pwg.images.upload"};
 
-    var asset = Asset(photo.path, photo.path.split('/').last, photo.size.ceil(), photo.size.ceil());
-
-    ByteData byteData = await asset.getByteData();
-    List<int> imageData = byteData.buffer.asUint8List();
+    List<int> imageData = await photo.readAsBytes();
 
     Dio dio = new Dio(
       BaseOptions(
@@ -103,7 +99,7 @@ class Uploader {
       print("Request failed: ${response.statusCode}");
     }
   }
-  Future<Response> uploadChunk(Media photo, String category, Map<String, dynamic> info) async {
+  Future<Response> uploadChunk(XFile photo, String category, Map<String, dynamic> info) async {
     Map<String, String> queries = {
       "format":"json",
       "method": "pwg.images.uploadAsync"

--- a/lib/views/CategoryViewPage.dart
+++ b/lib/views/CategoryViewPage.dart
@@ -2,7 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
-import 'package:images_picker/images_picker.dart';
+import 'package:image_picker/image_picker.dart';
 import 'dart:async';
 
 import 'package:piwigo_ng/api/API.dart';
@@ -423,15 +423,10 @@ class _CategoryViewPageState extends State<CategoryViewPage> with SingleTickerPr
           foregroundColor: _theme.floatingActionButtonTheme.foregroundColor,
           onTap: () async {
             try {
-              List<Media> mediaList = await ImagesPicker.pick(
-                count: 100,
-                pickType: PickType.all,
-                quality: 1.0,
-              );
-              print(mediaList[0].path);
-              if(mediaList.isNotEmpty) {
+              final List<XFile> images = await ImagePicker().pickMultiImage();
+              if(images.isNotEmpty) {
                 Navigator.push(context, MaterialPageRoute(
-                    builder: (context) => UploadGalleryViewPage(imageData: mediaList, category: widget.category)
+                    builder: (context) => UploadGalleryViewPage(imageData: images, category: widget.category)
                 )).whenComplete(() {
                   setState(() {
                     // API.uploader.createDio();
@@ -452,14 +447,10 @@ class _CategoryViewPageState extends State<CategoryViewPage> with SingleTickerPr
             foregroundColor: _theme.floatingActionButtonTheme.foregroundColor,
             onTap: () async {
               try {
-                List<Media> mediaList = await ImagesPicker.openCamera(
-                  pickType: PickType.image,
-                  quality: 1.0,
-                );
-                print(mediaList[0].path);
-                if(mediaList.isNotEmpty) {
+                final List<XFile> images = [await ImagePicker().pickImage(source: ImageSource.camera)];
+                if(images.isNotEmpty) {
                   Navigator.push(context, MaterialPageRoute(
-                      builder: (context) => UploadGalleryViewPage(imageData: mediaList, category: widget.category)
+                      builder: (context) => UploadGalleryViewPage(imageData: images, category: widget.category)
                   )).whenComplete(() {
                     setState(() {
                       print('After upload'); // refresh

--- a/lib/views/UploadGalleryViewPage.dart
+++ b/lib/views/UploadGalleryViewPage.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:images_picker/images_picker.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:piwigo_ng/constants/SettingsConstants.dart';
 import 'package:piwigo_ng/services/OrientationService.dart';
 import 'package:piwigo_ng/api/API.dart';
@@ -12,7 +12,7 @@ import 'package:piwigo_ng/views/components/textfields.dart';
 import 'package:piwigo_ng/views/components/dialogs/dialogs.dart';
 
 class UploadGalleryViewPage extends StatefulWidget {
-  final List<Media> imageData;
+  final List<XFile> imageData;
   final String category;
 
   UploadGalleryViewPage({Key key, this.imageData, this.category}) : super(key: key);
@@ -86,14 +86,11 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
 
   addFiles() async {
     try {
-      List<Media> mediaList = await ImagesPicker.pick(
-        count: 100,
-        pickType: PickType.all,
-        quality: 0.8,
-      );
-      print(mediaList[0].path);
+      List<XFile> mediaList = await ImagePicker().pickMultiImage();
       if(mediaList.isNotEmpty) {
-        widget.imageData.addAll(mediaList);
+        setState(() {
+          widget.imageData.addAll(mediaList);
+        });
       }
     } catch (e) {
       print('Dio error ${e.toString()}');
@@ -102,13 +99,11 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
 
   takePhoto() async {
     try {
-      List<Media> mediaList = await ImagesPicker.openCamera(
-        pickType: PickType.image,
-        quality: 0.8,
-      );
-      print(mediaList[0].path);
+      List<XFile> mediaList = [await ImagePicker().pickImage(source: ImageSource.camera)];
       if(mediaList.isNotEmpty) {
-        widget.imageData.addAll(mediaList);
+        setState(() {
+          widget.imageData.addAll(mediaList);
+        });
       }
     } catch (e) {
       print('Dio error ${e.toString()}');
@@ -136,6 +131,7 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
     await API.uploader.uploadPhotos(widget.imageData, widget.category, getImagesInfo());
     setState(() {
       _isLoading = false;
+      widget.imageData.clear();
     });
     Navigator.of(context).pop();
   }
@@ -240,7 +236,7 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
                     scrollDirection: Axis.vertical,
                     shrinkWrap: true,
                     itemBuilder: (BuildContext context, int index) {
-                      Media image = widget.imageData[index];
+                      XFile image = widget.imageData[index];
                       return Container(
                         child: Stack(
                           children: [
@@ -252,7 +248,7 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
                                 semanticContainer: true,
                                 child: GridTile(
                                   child: Container(
-                                    child: Image.file(File(image.thumbPath),
+                                    child: Image.file(File(image.path),
                                       fit: BoxFit.cover,
                                     ),
                                   ),
@@ -312,7 +308,7 @@ class _UploadGalleryViewPage extends State<UploadGalleryViewPage> {
                                     ),
                                     child: ClipRRect(
                                       borderRadius: BorderRadius.circular(7),
-                                      child: Image.file(File(image.thumbPath),
+                                      child: Image.file(File(image.path),
                                         fit: BoxFit.cover,
                                       ),
                                     ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,8 +36,7 @@ dependencies:
   flutter_local_notifications: ^9.1.2
 
   # File pickers :
-  multi_image_picker: ^4.8.01
-  images_picker: ^1.2.5
+  image_picker: ^0.8.4+4
   provider: ^6.0.1
   # camera: ^0.9.4+3
 


### PR DESCRIPTION
This closes #61 and uses image_picker of images_picker, since the former is maintained by the official flutter.dev team and is more robust. Using this package also removes the need for multi_image_picker, which was only used to get the ByteData.