### PR TITLE
Remove flutter_dotenv and .env asset

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:piwigo_ng/services/ThemeProvider.dart';
 import 'package:piwigo_ng/views/RootCategoryViewPage.dart';
@@ -13,7 +12,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  // await dotenv.load(fileName: ".env");
   SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
     statusBarColor: Colors.transparent,
   ));

--- a/lib/views/PrivacyPolicyViewPage.dart
+++ b/lib/views/PrivacyPolicyViewPage.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:piwigo_ng/constants/SettingsConstants.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 

--- a/lib/views/SettingsViewPage.dart
+++ b/lib/views/SettingsViewPage.dart
@@ -1,7 +1,6 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:piwigo_ng/constants/SettingsConstants.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
 
   # Local storage :
   shared_preferences: ^2.0.8
-  flutter_dotenv: ^5.0.2
   package_info_plus: ^1.3.0
 
   # Widgets :
@@ -81,7 +80,6 @@ flutter:
 
   assets:
     - assets/logo/piwigo_logo.png
-    - .env
 
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a


### PR DESCRIPTION
This is a PR to #67. I completed the removal of .env and the unused package.

Also, I had to change android:exported to "true" in order to install the app. Otherwise, when I try to install it on a device I get the following trace:

```ProcessException: Process exited abnormally:
Starting: Intent { act=android.intent.action.RUN flg=0x20000000 cmp=com.piwigo.piwigo_ng/com.remi.piwigo_ng.MainActivity (has extras) }


Exception occurred while executing 'start':
java.lang.SecurityException: Permission Denial: starting Intent { act=android.intent.action.RUN flg=0x30000000 cmp=com.piwigo.piwigo_ng/com.remi.piwigo_ng.MainActivity (has extras) } from null (pid=21674, uid=2000) not exported from uid 10436
	at com.android.server.wm.ActivityStackSupervisor.checkStartAnyActivityPermission(ActivityStackSupervisor.java:1032)
	at com.android.server.wm.ActivityStarter.executeRequest(ActivityStarter.java:999)
	at com.android.server.wm.ActivityStarter.execute(ActivityStarter.java:669)
	at com.android.server.wm.ActivityTaskManagerService.startActivityAsUser(ActivityTaskManagerService.java:1100)
	at com.android.server.wm.ActivityTaskManagerService.startActivityAsUser(ActivityTaskManagerService.java:1072)
	at com.android.server.am.ActivityManagerService.startActivityAsUserWithFeature(ActivityManagerService.java:3678)
	at com.android.server.am.ActivityManagerShellCommand.runStartActivity(ActivityManagerShellCommand.java:544)
	at com.android.server.am.ActivityManagerShellCommand.onCommand(ActivityManagerShellCommand.java:186)
	at android.os.BasicShellCommandHandler.exec(BasicShellCommandHandler.java:98)
	at android.os.ShellCommand.exec(ShellCommand.java:44)
	at com.android.server.am.ActivityManagerService.onShellCommand(ActivityManagerService.java:10522)
	at android.os.Binder.shellCommand(Binder.java:929)
	at android.os.Binder.onTransact(Binder.java:813)
	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:5027)
	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2883)
	at android.os.Binder.execTransactInternal(Binder.java:1159)
	at android.os.Binder.execTransact(Binder.java:1123)
  Command: /home/<USER>/Android/Sdk/platform-tools/adb -s HT7BW1A00364 shell am start -a android.intent.action.RUN -f 0x20000000 --ez enable-background-compilation true --ez enable-dart-profiling true --ez enable-checked-mode true --ez verify-entry-points true --ez start-paused true com.piwigo.piwigo_ng/com.remi.piwigo_ng.MainActivity
```

I used these resources to resolve the issue:
- https://github.com/flutter/flutter/issues/21396
- https://stackoverflow.com/questions/19829507/android-java-lang-securityexception-permission-denial-starting-intent