### PR TITLE
Show current values in Editing page (close #70)

### DIFF
--- a/lib/views/components/dialogs/images_dialogs.dart
+++ b/lib/views/components/dialogs/images_dialogs.dart
@@ -23,8 +23,8 @@ class EditImagesPage extends StatefulWidget {
 }
 class _EditImagesPageState extends State<EditImagesPage> {
   final _formKey = GlobalKey<FormState>();
-  TextEditingController _nameController = TextEditingController();
-  TextEditingController _descController = TextEditingController();
+  TextEditingController _nameController;
+  TextEditingController _descController;
 
   List<DropdownMenuItem<int>> _levelItems = [];
   List<TagModel> _tags = [];
@@ -37,6 +37,16 @@ class _EditImagesPageState extends State<EditImagesPage> {
   @override
   void initState() {
     super.initState();
+    
+    String initialName = "";
+    String initialDesc = "";
+    if (widget.images.length == 1) {
+      initialName = widget.images[_page]['name'] ?? "";
+      initialDesc = widget.images[_page]['comment'] ?? "";
+    }
+    _nameController = TextEditingController(text: initialName);
+    _descController = TextEditingController(text: initialDesc);
+
     _pageController = PageController(viewportFraction: 7/8);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       privacyLevels(context).forEach((key, value) {


### PR DESCRIPTION
This shows the current values for Title and Description only when
editing a single photo. Although it is possible that multiple photos
could share the same title/description, it hardly seems worth the effort
if the edits are batched to multiple photos anyways.