### PR TITLE
Replace video_player with better_player

### DIFF
--- a/lib/views/UploadGalleryViewPage.dart
+++ b/lib/views/UploadGalleryViewPage.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:video_player/video_player.dart';
+import 'package:better_player/better_player.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:piwigo_ng/constants/SettingsConstants.dart';
@@ -593,15 +593,24 @@ class VideoItem extends StatefulWidget {
   _VideoItemState createState() => _VideoItemState();
 }
 class _VideoItemState extends State<VideoItem> {
-  VideoPlayerController _controller;
+  BetterPlayerController _controller;
 
   @override
   void initState() {
     super.initState();
-    _controller = VideoPlayerController.file(File(widget.path))
-      ..initialize().then((_) {
-        setState(() {});
-      });
+    BetterPlayerDataSource betterPlayerDataSource = BetterPlayerDataSource.file(widget.path);
+    _controller = BetterPlayerController(
+        BetterPlayerConfiguration(
+          aspectRatio: 1,
+          autoPlay: true,
+          looping: true,
+          fit: BoxFit.cover,
+          controlsConfiguration: BetterPlayerControlsConfiguration(
+            showControls: false
+          ),
+        ),
+        betterPlayerDataSource: betterPlayerDataSource);
+    setState(() {});
   }
 
   @override
@@ -612,25 +621,18 @@ class _VideoItemState extends State<VideoItem> {
 
   @override
   Widget build(BuildContext context) {
-    if(_controller.value.isInitialized) {
-      return FittedBox(
-        fit: BoxFit.cover,
-        child: GestureDetector(
-          onTap: () {
-            setState(() {
-              _controller.value.isPlaying
-                  ? _controller.pause()
-                  : _controller.play();
-            });
-          },
-          child: SizedBox(
-            width: _controller.value.size?.width ?? 0,
-            height: _controller.value.size?.height ?? 0,
-            child: VideoPlayer(_controller),
-          ),
-        ),
+      return GestureDetector(
+        onTap: () {
+          setState(() {
+            _controller.isPlaying()
+                ? _controller.pause()
+                : _controller.play();
+          });
+        },
+        child: AspectRatio(
+          aspectRatio: 1,
+          child: BetterPlayer(controller: _controller),
+        )
       );
-    }
-    return CircularProgressIndicator();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,8 +56,6 @@ dependencies:
   photo_view: ^0.9.0
   cached_network_image: ^3.0.0
   better_player: ^0.0.79
-  video_player: ^2.2.10
-  video_thumbnail: ^0.4.6
   wakelock: ^0.5.6
 
 dev_dependencies:


### PR DESCRIPTION
Using both video_player and better_player results in Gradle failing to build the app.

Gradle Log:
```
Execution failed for task ':app:checkDebugDuplicateClasses'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class com.google.android.exoplayer2.ui.DownloadNotificationHelper found in modules jetified-exoplayer-core-2.17.0-runtime (com.google.android.exoplayer:exoplayer-core:2.17.0) and jetified-exoplayer-ui-2.15.1-runtime (com.google.android.exoplayer:exoplayer-ui:2.15.1)

     Go to the documentation to learn how to <a href="d.android.com/r/tools/classpath-sync-errors">Fix dependency resolution errors</a>.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 25s
Exception: Gradle task assembleDebug failed with exit code 1
```