### PR TITLE
Ext storage replace

### DIFF
--- a/lib/api/ImageAPI.dart
+++ b/lib/api/ImageAPI.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:ext_storage/ext_storage.dart';
+import 'package:external_path/external_path.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:path_provider/path_provider.dart';
@@ -84,7 +84,7 @@ Future<bool> _requestPermissions() async {
 }
 Future<String> _getDownloadPath() async {
   if (Platform.isAndroid) {
-    return ExtStorage.getExternalStoragePublicDirectory(ExtStorage.DIRECTORY_PICTURES);
+    return ExternalPath.getExternalStoragePublicDirectory(ExternalPath.DIRECTORY_PICTURES);
   }
   return (await getApplicationDocumentsDirectory()).path;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
       url: https://github.com/canewsin/flutter_absolute_path.git
   path_provider: ^2.0.7
   permission_handler: ^8.3.0
-  ext_storage: ^1.0.3 # Deprecated
   external_path: ^1.0.1
   flutter_local_notifications: ^9.1.2
 


### PR DESCRIPTION
Appears all the pieces were already in place to replace `ext_storage` - perhaps there was another reason it was being held onto? 

addresses #104 