### PR TITLE
Change ImageModel.name to nullable string

### DIFF
--- a/lib/components/cards/image_card.dart
+++ b/lib/components/cards/image_card.dart
@@ -80,7 +80,7 @@ class ImageCard extends StatelessWidget {
                             end: Alignment.topCenter),
                       ),
                       child: AutoSizeText(
-                        image.name,
+                        image.name ?? "",
                         maxLines: 1,
                         maxFontSize: 14,
                         minFontSize: 8,

--- a/lib/components/dialogs/image_comment_dialog.dart
+++ b/lib/components/dialogs/image_comment_dialog.dart
@@ -59,7 +59,7 @@ class _ImageCommentDialogState extends State<ImageCommentDialog> {
             curve: Curves.ease,
             opacity: isNameHidden ? 1.0 : 0.0,
             child: Text(
-              widget.image.name,
+              widget.image.name ?? "",
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.titleMedium,
@@ -78,7 +78,7 @@ class _ImageCommentDialogState extends State<ImageCommentDialog> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
-                widget.image.name,
+                widget.image.name ?? "",
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.titleMedium,
               ),

--- a/lib/components/modals/image_info_modal.dart
+++ b/lib/components/modals/image_info_modal.dart
@@ -45,7 +45,7 @@ class ImageInfoModal extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: Text(
-                image.name,
+                image.name ?? "",
                 style: Theme.of(context).textTheme.titleMedium,
               ),
             ),

--- a/lib/models/image_model.dart
+++ b/lib/models/image_model.dart
@@ -8,7 +8,7 @@ class ImageModel {
   int hit;
   bool favorite;
   String file;
-  String name;
+  String? name;
   String? comment;
   String? dateCreation;
   String? dateAvailable;
@@ -25,7 +25,7 @@ class ImageModel {
     this.hit = 0,
     this.favorite = false,
     this.file = '',
-    required this.name,
+    this.name,
     this.comment,
     this.dateCreation,
     this.dateAvailable,
@@ -43,7 +43,7 @@ class ImageModel {
         hit = int.tryParse(json['hit'].toString()) ?? 0,
         favorite = json['is_favorite'] ?? false,
         file = json['file'].toString(),
-        name = json['name'].toString(),
+        name = json['name']?.toString(),
         comment = json['comment'],
         dateCreation = json['date_creation'],
         dateAvailable = json['date_available'],

--- a/lib/utils/image_actions.dart
+++ b/lib/utils/image_actions.dart
@@ -188,7 +188,7 @@ Future<dynamic> onMovePhotos(BuildContext context, List<ImageModel> images,
       title: appStrings.moveImage_title,
       subtitle: appStrings.moveImage_selectAlbum(
         images.length,
-        images.first.name,
+        images.first.name ?? "",
       ),
       isImage: true,
       album: origin,

--- a/lib/views/image/edit_image_page.dart
+++ b/lib/views/image/edit_image_page.dart
@@ -51,7 +51,7 @@ class _EditImagePageState extends State<EditImagePage> {
     _authorController =
         TextEditingController(text: Preferences.getUploadAuthor);
     if (_imageList.length == 1) {
-      _titleController.text = _imageList.first.name;
+      _titleController.text = _imageList.first.name ?? "";
       _descriptionController.text = _imageList.first.comment ?? '';
       _tags = _imageList.first.tags;
     }

--- a/lib/views/image/image_page.dart
+++ b/lib/views/image/image_page.dart
@@ -345,7 +345,7 @@ class _ImagePageState extends State<ImagePage> {
                       ),
                       Expanded(
                         child: AutoSizeText(
-                          '${_currentImage.name}',
+                          '${_currentImage.name ?? ""}',
                           softWrap: true,
                           maxLines: 1,
                           maxFontSize: 16.0,


### PR DESCRIPTION
Currently if image name does not exist it is fetched in Json as null and this results in a very ugly name "null" displayed for those photos.

This PR changes ImageModel.name to nullable string (as it most certainly can be null coming from Piwigo web API).
Name is null-coalesced to empty string where used.

Alternatively of course it would be possible to just null-coalesce to empty string in ImageModel.fromJson() which would require no other modifications but this seems less elegant as it would hide the fact that non-existent name is possible and would differ from current handling of other nullable members in ImageModel.